### PR TITLE
Maintainer Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ lib
 include/openssl
 *.gz
 *.framework
+
+# Cossack Labs packaging
+output

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,109 @@
+# Set default goal for "make"
+.DEFAULT_GOAL := specs
+
+ifeq ($(MAKECMDGOALS),)
+GOAL := $(.DEFAULT_GOAL)
+else
+GOAL := $(MAKECMDGOALS)
+endif
+
+
+#===== Building ================================================================
+
+## Output directory
+OUTPUT ?= output
+
+## Build OpenSSL binaries
+build: $(OUTPUT)/done.build
+ifeq ($(GOAL),build)
+	@echo "Now you can package OpenSSL binaries:"
+	@echo
+	@echo "    make package"
+	@echo
+endif
+
+.PHONY: build
+
+$(OUTPUT)/done.build:
+	@./build-libssl.sh
+	@mkdir -p $(OUTPUT)
+	@touch $(OUTPUT)/done.build
+
+## Force rebuild of OpenSSL binaries
+rebuild:
+	@./build-libssl.sh
+	@mkdir -p $(OUTPUT)
+	@touch $(OUTPUT)/done.build
+ifeq ($(GOAL),rebuild)
+	@echo "Now you can package OpenSSL binaries:"
+	@echo
+	@echo "    make package"
+	@echo
+endif
+
+.PHONY: rebuild
+
+
+#===== Packaging ===============================================================
+
+## Prepare OpenSSL packages for upload
+packages: $(OUTPUT)/done.packages
+ifeq ($(GOAL),packages)
+	@echo "Now you can update package specs:"
+	@echo
+	@echo "    make specs"
+	@echo
+endif
+
+.PHONY: packages
+
+$(OUTPUT)/done.packages: $(OUTPUT)/done.build
+	@scripts/create-packages.sh
+	@mkdir -p $(OUTPUT)
+	@touch $(OUTPUT)/done.packages
+
+
+#===== Spec updates ============================================================
+
+## Update package spec files
+specs: $(OUTPUT)/done.specs
+ifeq ($(GOAL),specs)
+	@echo "Now you can commit the changes:"
+	@echo
+	@echo "    git add -p"
+	@echo "    git commit -em \"OpenSSL $$(cat "$(OUTPUT)/version")\""
+	@echo
+	@echo "Submit a pull request against the \"cossacklabs\" branch."
+	@echo "Wait for it to be merged, then prepare a signed release tag:"
+	@echo
+	@echo "    git checkout cossacklabs"
+	@echo "    git pull"
+	@echo "    git tag -sem \"OpenSSL $$(cat "$(OUTPUT)/version")\" v$$(cat "$(OUTPUT)/version")"
+	@echo "    git push --tags"
+	@echo
+	@echo "Finally, create a pre-release on GitHub from this tag:"
+	@echo
+	@echo "    https://github.com/cossacklabs/openssl-apple/releases/new"
+	@echo
+	@echo "and attach the following files to the release:"
+	@echo
+	@find $(OUTPUT) -type f -name 'openssl-*.zip' | sort | sed 's/^/    /g'
+	@echo
+endif
+
+.PHONY: specs
+
+$(OUTPUT)/done.specs: $(OUTPUT)/done.packages
+	@scripts/update-specs.sh
+	@mkdir -p $(OUTPUT)
+	@touch $(OUTPUT)/done.specs
+
+
+#===== Miscellaneous ===========================================================
+
+## Remove build artifacts
+clean:
+	@rm -rf bin lib src frameworks include/openssl
+	@rm -rf $(OUTPUT)
+
+.PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,24 @@ GOAL := $(MAKECMDGOALS)
 endif
 
 
+#===== Versioning ==============================================================
+
+## OpenSSL version to build
+VERSION ?= 1.0.2u
+
+BUILD_ARCHS   += ios_i386 ios_x86_64 ios_arm64 ios_armv7s ios_armv7
+BUILD_ARCHS   += mac_x86_64
+BUILD_TARGETS += ios-sim-cross-i386 ios-sim-cross-x86_64
+BUILD_TARGETS += ios64-cross-arm64 ios-cross-armv7s ios-cross-armv7
+BUILD_TARGETS += macos64-x86_64
+
+BUILD_FLAGS += --version=$(VERSION)
+BUILD_FLAGS += --archs="$(BUILD_ARCHS)"
+BUILD_FLAGS += --targets="$(BUILD_TARGETS)"
+BUILD_FLAGS += --min-ios-sdk=8.0
+BUILD_FLAGS += --min-macos-sdk=10.9
+
+
 #===== Building ================================================================
 
 ## Output directory
@@ -25,13 +43,13 @@ endif
 .PHONY: build
 
 $(OUTPUT)/done.build:
-	@./build-libssl.sh
+	@./build-libssl.sh $(BUILD_FLAGS)
 	@mkdir -p $(OUTPUT)
 	@touch $(OUTPUT)/done.build
 
 ## Force rebuild of OpenSSL binaries
 rebuild:
-	@./build-libssl.sh
+	@./build-libssl.sh $(BUILD_FLAGS)
 	@mkdir -p $(OUTPUT)
 	@touch $(OUTPUT)/done.build
 ifeq ($(GOAL),rebuild)
@@ -71,14 +89,17 @@ ifeq ($(GOAL),specs)
 	@echo "Now you can commit the changes:"
 	@echo
 	@echo "    git add -p"
-	@echo "    git commit -em \"OpenSSL $$(cat "$(OUTPUT)/version")\""
+	@echo "    git commit -em \"OpenSSL $(VERSION)\""
 	@echo
 	@echo "Submit a pull request against the \"cossacklabs\" branch."
 	@echo "Wait for it to be merged, then prepare a signed release tag:"
 	@echo
 	@echo "    git checkout cossacklabs"
 	@echo "    git pull"
-	@echo "    git tag -sem \"OpenSSL $$(cat "$(OUTPUT)/version")\" v$$(cat "$(OUTPUT)/version")"
+	@echo
+	@echo "    # The tag must contain the 'semversified' version of OpenSSL"
+	@echo "    # (e.g., $$(cat "$(OUTPUT)/version") instead of $(VERSION))"
+	@echo "    git tag -sem \"OpenSSL $(VERSION)\" v$$(cat "$(OUTPUT)/version")"
 	@echo "    git push --tags"
 	@echo
 	@echo "Finally, create a pre-release on GitHub from this tag:"

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -25,18 +25,18 @@ set -u
 # SCRIPT DEFAULTS
 
 # Default version in case no version is specified
-DEFAULTVERSION="1.0.2u"
+DEFAULTVERSION="1.1.1g"
 
 # Default (=full) set of architectures (OpenSSL <= 1.0.2) or targets (OpenSSL >= 1.1.1) to build
-#DEFAULTARCHS="ios_i386 ios_x86_64 ios_arm64 ios_armv7s ios_armv7 tv_x86_64 tv_arm64 mac_x86_64 watchos_armv7k watchos_arm64_32 watchos_i386"
-#DEFAULTTARGETS="ios-sim-cross-i386 ios-sim-cross-x86_64 ios64-cross-arm64 ios64-cross-arm64e ios-cross-armv7s ios-cross-armv7 tvos-sim-cross-x86_64 tvos64-cross-arm64 macos64-x86_64 watchos-cross-armv7k watchos-cross-arm64_32 watchos-sim-cross-i386"
-DEFAULTARCHS="ios_i386 ios_x86_64 ios_arm64 ios_armv7s ios_armv7 mac_x86_64"
-DEFAULTTARGETS="ios-sim-cross-i386 ios-sim-cross-x86_64 ios64-cross-arm64 ios-cross-armv7s ios-cross-armv7 macos64-x86_64"
+#DEFAULTARCHS="ios_x86_64 ios_arm64 ios_armv7s ios_armv7 tv_x86_64 tv_arm64 mac_x86_64"
+#DEFAULTTARGETS="ios-sim-cross-x86_64 ios64-cross-arm64 ios-cross-armv7s ios-cross-armv7 tvos-sim-cross-x86_64 tvos64-cross-arm64 macos64-x86_64"
+DEFAULTARCHS="ios_x86_64 ios_arm64 tv_x86_64 tv_arm64 mac_x86_64 watchos_armv7k watchos_arm64_32 watchos_i386"
+DEFAULTTARGETS="ios-sim-cross-x86_64 ios64-cross-arm64 ios64-cross-arm64e tvos-sim-cross-x86_64 tvos64-cross-arm64 macos64-x86_64 watchos-cross-armv7k watchos-cross-arm64_32 watchos-sim-cross-i386"
 
 # Minimum iOS/tvOS SDK version to build for
-IOS_MIN_SDK_VERSION="8.0"
+IOS_MIN_SDK_VERSION="12.0"
 TVOS_MIN_SDK_VERSION="12.0"
-MACOS_MIN_SDK_VERSION="10.9"
+MACOS_MIN_SDK_VERSION="10.15"
 WATCHOS_MIN_SDK_VERSION="4.0"
 
 # Init optional env variables (use available variable or default to empty string)

--- a/carthage/openssl-dynamic-MacOSX.json
+++ b/carthage/openssl-dynamic-MacOSX.json
@@ -1,0 +1,3 @@
+{
+    "1.0.221": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.0.2u/openssl-macOS.zip"
+}

--- a/carthage/openssl-dynamic-iPhone.json
+++ b/carthage/openssl-dynamic-iPhone.json
@@ -1,0 +1,3 @@
+{
+    "1.0.221": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.0.2u/openssl-iOS.zip"
+}

--- a/carthage/openssl-static-MacOSX.json
+++ b/carthage/openssl-static-MacOSX.json
@@ -1,0 +1,3 @@
+{
+    "1.0.221": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.0.2u/openssl-static-macOS.zip"
+}

--- a/carthage/openssl-static-iPhone.json
+++ b/carthage/openssl-static-iPhone.json
@@ -1,0 +1,3 @@
+{
+    "1.0.221": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.0.2u/openssl-static-iOS.zip"
+}

--- a/scripts/create-packages.sh
+++ b/scripts/create-packages.sh
@@ -25,12 +25,12 @@ die() {
 
 if [[ ! -f create-openssl-framework.sh ]]
 then
-    die "Please run \"scripts/create-package.sh\" from repository root."
+    die 'Please run "scripts/create-package.sh" from repository root.'
 fi
 
 if [[ ! -d lib ]]
 then
-    die "No OpenSSL binaries. Please run \"./build-libssl.sh\" first."
+    die 'No OpenSSL binaries. Please run "./build-libssl.sh" first.'
 fi
 
 # Print framework bundle version (CFBundleShortVersionString property).

--- a/scripts/create-packages.sh
+++ b/scripts/create-packages.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Create packages of Cossack Labs' OpenSSL.
+#
+#     scripts/create-packages.sh
+#
+# Run this after building OpenSSL with "./build-libssl.sh".
+#
+# Environment variables:
+#
+#     OUTPUT        output directory            (default: output)
+#     FLAVORS       package flavors to build    (default: static dynamic)
+#     PLATFORMS     platforms to package for    (default: iPhone MacOSX)
+
+set -eu
+
+OUTPUT=${OUTPUT:-output}
+FLAVORS=${FLAVORS:-static dynamic}
+PLATFORMS=${PLATFORMS:-iPhone MacOSX}
+
+die() {
+    echo 2>&1 "$@"
+    exit 1
+}
+
+if [[ ! -f create-openssl-framework.sh ]]
+then
+    die "Please run \"scripts/create-package.sh\" from repository root."
+fi
+
+if [[ ! -d lib ]]
+then
+    die "No OpenSSL binaries. Please run \"./build-libssl.sh\" first."
+fi
+
+# Print framework bundle version (CFBundleShortVersionString property).
+framework_version() {
+    local fmwk="$1"
+    # Info.plist may be located in different places depending on the target OS.
+    local info_plist="$(find "$fmwk" -type f -name Info.plist)"
+    # It's not that well-known, but it's a standard utility after all.
+    # "plutil" is not very convenient for extracting individual values.
+    /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$info_plist"
+}
+
+mkdir -p "$OUTPUT"
+
+for flavor in $FLAVORS
+do
+    ./create-openssl-framework.sh $flavor
+
+    for platform in $PLATFORMS
+    do
+        echo "Packaging $flavor framework for $platform"
+
+        # zip stores relative paths, cd into directory to keep them tidy.
+        # Is also important to preserve symlinks for macOS frameworks.
+        cd frameworks/$platform
+        zip --recurse-paths --symlinks --quiet \
+            openssl.zip openssl.framework
+        cd "$OLDPWD"
+
+        mv frameworks/$platform/openssl.zip \
+            "$OUTPUT/openssl-$flavor-$platform.zip"
+
+        framework_version frameworks/$platform/openssl.framework \
+            > "$OUTPUT/version"
+
+        echo "Packaged $flavor framework for $platform"
+    done
+done

--- a/scripts/update-specs.sh
+++ b/scripts/update-specs.sh
@@ -21,7 +21,7 @@ die() {
 
 if [[ ! -f "$OUTPUT/version" ]]
 then
-    die "No package version. Run \"scripts/create-packages.sh\" first."
+    die 'No package version. Run "scripts/create-packages.sh" first.'
 fi
 
 version="$(cat "$OUTPUT/version")"

--- a/scripts/update-specs.sh
+++ b/scripts/update-specs.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Update package spec files of Cossack Labs' OpenSSL.
+#
+#     scripts/update-specs.sh
+#
+# Run this after packaging OpenSSL with "scripts/create-packages.sh".
+#
+# Environment variables:
+#
+#     OUTPUT        output directory            (default: output)
+
+set -eu
+
+OUTPUT=${OUTPUT:-output}
+
+die() {
+    echo 2>&1 "$@"
+    exit 1
+}
+
+if [[ ! -f "$OUTPUT/version" ]]
+then
+    die "No package version. Run \"scripts/create-packages.sh\" first."
+fi
+
+version="$(cat "$OUTPUT/version")"
+
+# Carthage
+for package in "$OUTPUT"/openssl-*.zip
+do
+    package="$(basename "$package")"
+    spec="carthage/${package%%.zip}.json"
+    if grep -q "\"$version\"" "$spec"
+    then
+        echo "OpenSSL $version is already present in $spec"
+    else
+        (
+            head -1 "$spec" 2> /dev/null || echo "{"
+            echo "    \"$version\": \"https://github.com/cossacklabs/openssl-apple/releases/download/v$version/$package\","
+            tail +2 "$spec" 2> /dev/null || echo "}"
+        ) > "$OUTPUT/tmp.spec"
+        mv "$OUTPUT/tmp.spec" "$spec"
+    fi
+done


### PR DESCRIPTION
Add a Makefile to make releasing new versions easier. It encapsulates common tasks for preparing a release. With this Makefile, the release flow should be something like this:

 1. Update OpenSSL version in `Makefile`, add tarball checksum in `build-libssl.sh` if necessary.

    Update minimum and target API versions as necessary too.

 2. Run `make`. Wait.
    <sup>(**ProTip:** if you put your laptop upside down, you can make yourself an omelette in the meantime.)</sup>

 3. Commit, tag, push changes.

 4. Create GitHub release, attach framework packages from `output`.

Currently we support only Carthage publishing. Carthage packages are published when the tag and commit are pushed.

Later CocoaPods will be added into the flow. This will require additional validation step *after* the tag is published and GitHub release is created, followed by manual podspec publishing.

Carthage binary project specs have a new naming, more consistent with platform names used by OpenSSL build scripts. However, we still keep the old specs around because they may still be needed on the _cossacklabs_ branch. They can be removed only after the release is made, when we are sure that all users of the experimental branches have migrated away.

Also, newer version of the `build-libssl.sh` script allows more configurability so we do not have to modify it to achieve what we want. Roll back our changes and move them into the Makefile instead, changing relevant defaults using the command-line options.

P.S. Why spend an hour doing it manually if you can spend a week automating it? Because advancements have to be made.