### PR TITLE
CocoaPods spec: CLOpenSSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ endif
 ## OpenSSL version to build
 VERSION ?= 1.0.2u
 
+MIN_IOS_SDK = 8.0
+MIN_OSX_SDK = 10.9
+
 BUILD_ARCHS   += ios_i386 ios_x86_64 ios_arm64 ios_armv7s ios_armv7
 BUILD_ARCHS   += mac_x86_64
 BUILD_TARGETS += ios-sim-cross-i386 ios-sim-cross-x86_64
@@ -22,8 +25,8 @@ BUILD_TARGETS += macos64-x86_64
 BUILD_FLAGS += --version=$(VERSION)
 BUILD_FLAGS += --archs="$(BUILD_ARCHS)"
 BUILD_FLAGS += --targets="$(BUILD_TARGETS)"
-BUILD_FLAGS += --min-ios-sdk=8.0
-BUILD_FLAGS += --min-macos-sdk=10.9
+BUILD_FLAGS += --min-ios-sdk=$(MIN_IOS_SDK)
+BUILD_FLAGS += --min-macos-sdk=$(MIN_OSX_SDK)
 
 
 #===== Building ================================================================

--- a/cocoapods/.gitignore
+++ b/cocoapods/.gitignore
@@ -1,0 +1,3 @@
+# Keep generated file on maintainer's machine only,
+# no need to duplicate it with the template.
+CLOpenSSL.podspec

--- a/cocoapods/CLOpenSSL.podspec.template
+++ b/cocoapods/CLOpenSSL.podspec.template
@@ -1,0 +1,214 @@
+Pod::Spec.new do |s|
+    # These parts of the spec are filled in by the template generator.
+    openssl_version = "%%OPENSSL_VERSION%%"
+    min_target_ios  = "%%MIN_IOS_SDK%%"
+    min_target_osx  = "%%MIN_OSX_SDK%%"
+
+    github_repo = "%%GITHUB_REPO%%"
+    iPhone_archive_name = "%%IPHONE_ARCHIVE_NAME%%"
+    iPhone_archive_hash = "%%IPHONE_ARCHIVE_HASH%%"
+    macOSX_archive_name = "%%MACOSX_ARCHIVE_NAME%%"
+    macOSX_archive_hash = "%%MACOSX_ARCHIVE_HASH%%"
+
+    # Project metadata
+    s.name     = "CLOpenSSL"
+    s.version  = "#{openssl_version}"
+    s.summary  = "Robust, commercial-grade, and full-featured toolkit for the TLS and SSL protocols as well as a general-purpose cryptography library."
+    s.homepage = "https://www.openssl.org/"
+    s.authors  = [
+        "Andy Polyakov",
+        "Ben Laurie",
+        "Ben Kaduk",
+        "Bernd Edlinger",
+        "Bodo Möller",
+        "David Benjamin",
+        "Emilia Käsper",
+        "Eric Young",
+        "Geoff Thorpe",
+        "Holger Reif",
+        "Kurt Roeckx",
+        "Lutz Jänicke",
+        "Mark J. Cox",
+        "Matt Caswell",
+        "Matthias St. Pierre",
+        "Nils Larsch",
+        "Paul Dale",
+        "Paul C. Sutton",
+        "Ralf S. Engelschall",
+        "Rich Salz",
+        "Richard Levitte",
+        "Stephen Henson",
+        "Steve Marquess",
+        "Tim Hudson",
+        "Ulf Möller",
+        "Viktor Dukhovni",
+    ]
+
+    # Source code location. Actually, this is the script that builds OpenSSL
+    # after downloading its source tarball from the official site.
+    s.source  = { :git => "#{github_repo}.git", :tag => "v#{openssl_version}" }
+    s.license = {
+        :type => "OpenSSL/SSLeay",
+        :text => <<~EOF
+
+        LICENSE ISSUES
+        ==============
+
+        The OpenSSL toolkit stays under a double license, i.e. both the conditions of
+        the OpenSSL License and the original SSLeay license apply to the toolkit.
+        See below for the actual license texts.
+
+        OpenSSL License
+        ---------------
+
+      /* ====================================================================
+       * Copyright (c) 1998-2019 The OpenSSL Project.  All rights reserved.
+       *
+       * Redistribution and use in source and binary forms, with or without
+       * modification, are permitted provided that the following conditions
+       * are met:
+       *
+       * 1. Redistributions of source code must retain the above copyright
+       *    notice, this list of conditions and the following disclaimer.
+       *
+       * 2. Redistributions in binary form must reproduce the above copyright
+       *    notice, this list of conditions and the following disclaimer in
+       *    the documentation and/or other materials provided with the
+       *    distribution.
+       *
+       * 3. All advertising materials mentioning features or use of this
+       *    software must display the following acknowledgment:
+       *    "This product includes software developed by the OpenSSL Project
+       *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+       *
+       * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+       *    endorse or promote products derived from this software without
+       *    prior written permission. For written permission, please contact
+       *    openssl-core@openssl.org.
+       *
+       * 5. Products derived from this software may not be called "OpenSSL"
+       *    nor may "OpenSSL" appear in their names without prior written
+       *    permission of the OpenSSL Project.
+       *
+       * 6. Redistributions of any form whatsoever must retain the following
+       *    acknowledgment:
+       *    "This product includes software developed by the OpenSSL Project
+       *    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+       *
+       * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+       * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+       * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+       * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+       * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+       * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+       * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+       * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+       * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+       * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+       * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+       * OF THE POSSIBILITY OF SUCH DAMAGE.
+       * ====================================================================
+       *
+       * This product includes cryptographic software written by Eric Young
+       * (eay@cryptsoft.com).  This product includes software written by Tim
+       * Hudson (tjh@cryptsoft.com).
+       *
+       */
+
+       Original SSLeay License
+       -----------------------
+
+      /* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+       * All rights reserved.
+       *
+       * This package is an SSL implementation written
+       * by Eric Young (eay@cryptsoft.com).
+       * The implementation was written so as to conform with Netscapes SSL.
+       *
+       * This library is free for commercial and non-commercial use as long as
+       * the following conditions are aheared to.  The following conditions
+       * apply to all code found in this distribution, be it the RC4, RSA,
+       * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
+       * included with this distribution is covered by the same copyright terms
+       * except that the holder is Tim Hudson (tjh@cryptsoft.com).
+       *
+       * Copyright remains Eric Young's, and as such any Copyright notices in
+       * the code are not to be removed.
+       * If this package is used in a product, Eric Young should be given attribution
+       * as the author of the parts of the library used.
+       * This can be in the form of a textual message at program startup or
+       * in documentation (online or textual) provided with the package.
+       *
+       * Redistribution and use in source and binary forms, with or without
+       * modification, are permitted provided that the following conditions
+       * are met:
+       * 1. Redistributions of source code must retain the copyright
+       *    notice, this list of conditions and the following disclaimer.
+       * 2. Redistributions in binary form must reproduce the above copyright
+       *    notice, this list of conditions and the following disclaimer in the
+       *    documentation and/or other materials provided with the distribution.
+       * 3. All advertising materials mentioning features or use of this software
+       *    must display the following acknowledgement:
+       *    "This product includes cryptographic software written by
+       *     Eric Young (eay@cryptsoft.com)"
+       *    The word 'cryptographic' can be left out if the rouines from the library
+       *    being used are not cryptographic related :-).
+       * 4. If you include any Windows specific code (or a derivative thereof) from
+       *    the apps directory (application code) you must include an acknowledgement:
+       *    "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
+       *
+       * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
+       * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+       * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+       * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+       * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+       * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+       * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+       * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+       * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+       * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+       * SUCH DAMAGE.
+       *
+       * The licence and distribution terms for any publically available version or
+       * derivative of this code cannot be changed.  i.e. this code cannot simply be
+       * copied and put under another distribution licence
+       * [including the GNU Public Licence.]
+       */
+EOF
+    }
+
+    # This is where all the action happens. Since OpenSSL is so huge and building it
+    # properly is so painful to setup, "pod install" will download prebuilt binaries
+    # that we publish elsewhere (not in the git repo with the build script code).
+    s.prepare_command = <<-EOF
+        (
+            echo "#{iPhone_archive_name} #{iPhone_archive_hash}"
+            echo "#{macOSX_archive_name} #{macOSX_archive_hash}"
+        ) | while read name hash
+        do
+            echo "Downloading $name..."
+            curl --location --output "$name" \
+                "#{github_repo}/releases/download/v#{openssl_version}/$name"
+            echo "Verifying $name..."
+            if [[ "$(shasum -a 256 "$name" | awk '{print $1}')" != "$hash" ]]
+            then
+                echo "Checksum mismatch for $name"
+                exit 1
+            fi
+            echo "Unpacking $name..."
+            unzip "$name"
+            rm "$name"
+            mkdir -p "$name"
+            mv openssl.framework "$name"
+        done
+    EOF
+
+    # Set the minimum platform versions. We just know the right ones from the
+    # prebuilt frameworks we download.
+    s.ios.deployment_target = min_target_ios
+    s.osx.deployment_target = min_target_osx
+
+    # These are prebuilt frameworks that will be vendored into the final app.
+    s.ios.vendored_frameworks = "#{iPhone_archive_name}/openssl.framework"
+    s.osx.vendored_frameworks = "#{macOSX_archive_name}/openssl.framework"
+end

--- a/cocoapods/CLOpenSSL.podspec.template
+++ b/cocoapods/CLOpenSSL.podspec.template
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
     # Project metadata
     s.name     = "CLOpenSSL"
     s.version  = "#{openssl_version}"
-    s.summary  = "Robust, commercial-grade, and full-featured toolkit for the TLS and SSL protocols as well as a general-purpose cryptography library."
+    s.summary  = "Pre-built OpenSSL framework for iOS and macOS: full-featured toolkit for the TLS and SSL protocols as well as a general-purpose cryptography library."
     s.homepage = "https://www.openssl.org/"
     s.authors  = [
         "Andy Polyakov",

--- a/scripts/update-specs.sh
+++ b/scripts/update-specs.sh
@@ -9,10 +9,29 @@
 # Environment variables:
 #
 #     OUTPUT        output directory            (default: output)
+#     MIN_IOS_SDK   minimum iOS SDK version     (default: 8.0)
+#     MIN_OSX_SDK   minimum macOS SDK version   (default: 10.9)
 
 set -eu
 
 OUTPUT=${OUTPUT:-output}
+MIN_IOS_SDK=${MIN_IOS_SDK:-8.0}
+MIN_OSX_SDK=${MIN_OSX_SDK:-10.9}
+
+# GitHub repository where build script and binaries are hosted
+GITHUB_REPO="https://github.com/cossacklabs/openssl-apple"
+
+# Output framework archive names
+IPHONE_STATIC_NAME="openssl-static-iPhone.zip"
+MACOSX_STATIC_NAME="openssl-static-MacOSX.zip"
+IPHONE_DYNAMIC_NAME="openssl-dynamic-iPhone.zip"
+MACOSX_DYNAMIC_NAME="openssl-dynamic-MacOSX.zip"
+OUTPUT_ARCHIVES=(
+    "$IPHONE_STATIC_NAME"
+    "$MACOSX_STATIC_NAME"
+    "$IPHONE_DYNAMIC_NAME"
+    "$MACOSX_DYNAMIC_NAME"
+)
 
 die() {
     echo 2>&1 "$@"
@@ -27,9 +46,8 @@ fi
 version="$(cat "$OUTPUT/version")"
 
 # Carthage
-for package in "$OUTPUT"/openssl-*.zip
+for package in "${OUTPUT_ARCHIVES[@]}"
 do
-    package="$(basename "$package")"
     spec="carthage/${package%%.zip}.json"
     if grep -q "\"$version\"" "$spec"
     then
@@ -37,9 +55,26 @@ do
     else
         (
             head -1 "$spec" 2> /dev/null || echo "{"
-            echo "    \"$version\": \"https://github.com/cossacklabs/openssl-apple/releases/download/v$version/$package\","
+            echo "    \"$version\": \"$GITHUB_REPO/releases/download/v$version/$package\","
             tail +2 "$spec" 2> /dev/null || echo "}"
         ) > "$OUTPUT/tmp.spec"
         mv "$OUTPUT/tmp.spec" "$spec"
     fi
 done
+echo "Updated carthage/*.json"
+echo
+
+# Unfortuntely, CocoaPods does not support static frameworks very well
+# so we provide only dynamic flavor of the Podspec.
+podspec="cocoapods/CLOpenSSL.podspec"
+sed -e "s/%%OPENSSL_VERSION%%/$version/g" \
+    -e "s!%%GITHUB_REPO%%!$GITHUB_REPO!g" \
+    -e "s/%%MIN_IOS_SDK%%/$MIN_IOS_SDK/g" \
+    -e "s/%%MIN_OSX_SDK%%/$MIN_OSX_SDK/g" \
+    -e "s/%%IPHONE_ARCHIVE_NAME%%/$IPHONE_DYNAMIC_NAME/g" \
+    -e "s/%%IPHONE_ARCHIVE_HASH%%/$(shasum -a 256 "$OUTPUT/$IPHONE_DYNAMIC_NAME" | awk '{print $1}')/g" \
+    -e "s/%%MACOSX_ARCHIVE_NAME%%/$MACOSX_DYNAMIC_NAME/g" \
+    -e "s/%%MACOSX_ARCHIVE_HASH%%/$(shasum -a 256 "$OUTPUT/$MACOSX_DYNAMIC_NAME" | awk '{print $1}')/g" \
+    $podspec.template > $podspec
+echo "Updated $podspec"
+echo


### PR DESCRIPTION
Support publishing our OpenSSL build on CocoaPods. Now running `make specs` will also generate **CLOpenSSL.podspec** which can be uploaded to CocoaPods repositories.

The spec does not actually build OpenSSL on the user machine. Instead, it downloads prebuilt frameworks (the same as used by Carthage). This results in considerable savings of the installation time. The framework binaries are currently hosted as GitHub releases. Not checking them into the repository also gives some savings (or rather, will give over time).

Since the spec still clones *this* repository, it will be possible to build OpenSSL from source on developers' machines, if needed.

Only dynamic frameworks are supported with CocoaPods. There is an option to include static frameworks, but that does not work out of the box and is very inconvenient for us to support.

Note that at the moment there is no `v1.0.221` tag in this repository so the produced Podspec will not pass linting. It can be properly and fully linted only after the tag is published. (That's how Cocoapods works.)