### PR TITLE
Update to OpenSSL 1.1.1g

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 #===== Versioning ==============================================================
 
 ## OpenSSL version to build
-VERSION ?= 1.0.2u
+VERSION ?= 1.1.1g
 
 BUILD_ARCHS   += ios_i386 ios_x86_64 ios_arm64 ios_armv7s ios_armv7
 BUILD_ARCHS   += mac_x86_64

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -487,6 +487,7 @@ fi
 # and at https://www.openssl.org/source/old/ for old releases.
 OPENSSL_CHECKSUMS="
   1.0.2u ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16
+  1.1.1g ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46
 "
 checksum_checked=false
 while read version expectedSHA256; do


### PR DESCRIPTION
As of now, OpenSSL 1.1.1g is the latest stable version of OpenSSL.