### PR TITLE
Build OpenSSL for arm64e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ VERSION ?= 1.1.1g
 MIN_IOS_SDK = 8.0
 MIN_OSX_SDK = 10.9
 
-BUILD_ARCHS   += ios_i386 ios_x86_64 ios_arm64 ios_armv7s ios_armv7
+BUILD_ARCHS   += ios_i386 ios_x86_64 ios_arm64 ios_arm64e ios_armv7s ios_armv7
 BUILD_ARCHS   += mac_x86_64
 BUILD_TARGETS += ios-sim-cross-i386 ios-sim-cross-x86_64
-BUILD_TARGETS += ios64-cross-arm64 ios-cross-armv7s ios-cross-armv7
+BUILD_TARGETS += ios64-cross-arm64 ios64-cross-arm64e ios-cross-armv7s ios-cross-armv7
 BUILD_TARGETS += macos64-x86_64
 
 BUILD_FLAGS += --version=$(VERSION)


### PR DESCRIPTION
I have missed this architecture from the default list. It is important for [more security features of iOS][1], let's add it. The architecture has been available for a while, and it looks like latest devices are going to require it.

[1]: https://developer.apple.com/documentation/security/preparing_your_app_to_work_with_pointer_authentication

This issue has been found and pointed out by @vixentael. It seems that the 1.1.107 release will need to be updated with this change because without it OpenSSL may block development for latest devices. It is known to break builds with Xcode 12 beta.