### PR TITLE
Use original OpenSSL version for static frameworks

### DIFF
--- a/create-openssl-framework.sh
+++ b/create-openssl-framework.sh
@@ -106,6 +106,10 @@ function get_min_sdk() {
 function get_openssl_version() {
     local opensslv=$1
     local std_version=$(awk '/define OPENSSL_VERSION_TEXT/ && !/-fips/ {print $5}' "$opensslv")
+    if [[ "$NORMALIZE_OPENSSL_VERSION" != "yes" ]]; then
+        echo $std_version
+        return
+    fi
     local generic_version=${std_version%?}
     local subpatch=${std_version: -1}
     local subpatch_number=$(($(printf '%d' \'$subpatch) - 97 + 1))
@@ -119,6 +123,7 @@ if [ $FWTYPE == "dynamic" ]; then
     INSTALL_NAME="@rpath/${FW_EXEC_NAME}"
     COMPAT_VERSION="1.0.0"
     CURRENT_VERSION="1.0.0"
+    NORMALIZE_OPENSSL_VERSION=yes
 
     RX='([A-z]+)([0-9]+(\.[0-9]+)*)-([A-z0-9]+)\.sdk'
 
@@ -206,6 +211,8 @@ if [ $FWTYPE == "dynamic" ]; then
 
     rm bin/*/$FWNAME.dylib
 else
+    NORMALIZE_OPENSSL_VERSION=no
+
     for SYS in ${ALL_SYSTEMS[@]}; do
         SYSDIR="$FWROOT/$SYS"
         FWDIR="$SYSDIR/$FWNAME.framework"


### PR DESCRIPTION
...but use the semversified version for dynamic frameworks. That is, for OpenSSL 1.1.1g static frameworks will have `1.1.1g` in their Info.plist, dynamic frameworks will have `1.1.107` in their Info.plist, and the tag on the repository will be `v1.1.107`.

<p>
<sub>
This is because we need to keep the version in static frameworks distributed for Carthage (static ones) so that certain dependency checkers are happy. We need to modify the version in dynamic frameworks as they are going to be included into the app bundle and we need to make the App Store happy. We need to have the tag semver-valid too because Carthage needs to be still happy. But what if there is CocoaPods project which also uses a dependency checked which will be thrown off guard with a weird OpenSSL version? Well, the thing is, you as a maintainer are not entitled to be happy. All package managers apparently want you to suffer until you submit to their demands, so does the App Store where all the apps are going to be submitted. Ultimately, you do want that shiny money, right? If you didn't, you'd be working for a different ecosystem. IDK, making desktop Linux great again, or Plan 9, or Raku.
</sub>

<p>
<sub>
There is a moment when a person breaks. This is it for me. If someone demands the version to be a picture, or a dance, or a poem, then the version will be just that. If this commit causes you trouble—whoever is reading this in `git blame`—because you don't understand why the versioning is so weird, why there is this change that causes merge conflicts, why your customers are not happy because a weird version of dependency of a dependency prevents the app from validating. If any of this happens, please know that I'm deeply sorry for this, but it's your turn. I hope you can make the world a better place, as I hope that no one will have to touch this magic and it will continue working long past anyone remembers why. Until it breaks, that is.
</sub>

<p>
<sub>
It's 3:20 AM and I probably should not be submitting this change, waiting for a cool down, but... whatever 🤷
</sub>