### PR TITLE
Drop historical Carthage specs

### DIFF
--- a/carthage/openssl-iOS.json
+++ b/carthage/openssl-iOS.json
@@ -1,3 +1,0 @@
-{
-    "1.0.221": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.0.2u/openssl-iOS.zip"
-}

--- a/carthage/openssl-macOS.json
+++ b/carthage/openssl-macOS.json
@@ -1,3 +1,0 @@
-{
-    "1.0.221": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.0.2u/openssl-macOS.zip"
-}

--- a/carthage/openssl-static-iOS.json
+++ b/carthage/openssl-static-iOS.json
@@ -1,3 +1,0 @@
-{
-    "1.0.221": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.0.2u/openssl-static-iOS.zip"
-}

--- a/carthage/openssl-static-macOS.json
+++ b/carthage/openssl-static-macOS.json
@@ -1,3 +1,0 @@
-{
-    "1.0.221": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.0.2u/openssl-static-macOS.zip"
-}


### PR DESCRIPTION
Now all production users are using new, consistently named spec files. Drop old files which are not actively used by any of our projects.

The only current user is Themis 0.13.2:
https://github.com/cossacklabs/themis/blob/0.13.2/Cartfile#L1-L3
which uses the new specs.