### PR TITLE
Apple Silicon support

### DIFF
--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -182,6 +182,10 @@ finish_build_loop()
     LIBSSL_WATCHOS+=("${TARGETDIR}/lib/libssl.a")
     LIBCRYPTO_WATCHOS+=("${TARGETDIR}/lib/libcrypto.a")
     OPENSSLCONF_SUFFIX="watchos_${ARCH}"
+  elif [[ "${PLATFORM}" == iPhoneSimulator* ]]; then
+    LIBSSL_IOS+=("${TARGETDIR}/lib/libssl.a")
+    LIBCRYPTO_IOS+=("${TARGETDIR}/lib/libcrypto.a")
+    OPENSSLCONF_SUFFIX="ios_sim_${ARCH}"
   elif [[ "${PLATFORM}" == iPhone* ]]; then
     LIBSSL_IOS+=("${TARGETDIR}/lib/libssl.a")
     LIBCRYPTO_IOS+=("${TARGETDIR}/lib/libcrypto.a")
@@ -615,10 +619,10 @@ if [ ${#OPENSSLCONF_ALL[@]} -gt 1 ]; then
       *_macos_i386.h)
         DEFINE_CONDITION="TARGET_OS_OSX && TARGET_CPU_X86"
       ;;
-      *_ios_x86_64.h)
+      *_ios_sim_x86_64.h)
         DEFINE_CONDITION="TARGET_OS_IOS && TARGET_OS_SIMULATOR && TARGET_CPU_X86_64"
       ;;
-      *_ios_i386.h)
+      *_ios_sim_i386.h)
         DEFINE_CONDITION="TARGET_OS_IOS && TARGET_OS_SIMULATOR && TARGET_CPU_X86"
       ;;
       *_ios_arm64.h)

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -619,11 +619,17 @@ if [ ${#OPENSSLCONF_ALL[@]} -gt 1 ]; then
       *_macos_i386.h)
         DEFINE_CONDITION="TARGET_OS_OSX && TARGET_CPU_X86"
       ;;
+      *_macos_arm64.h)
+        DEFINE_CONDITION="TARGET_OS_OSX && TARGET_CPU_ARM64"
+      ;;
       *_ios_sim_x86_64.h)
         DEFINE_CONDITION="TARGET_OS_IOS && TARGET_OS_SIMULATOR && TARGET_CPU_X86_64"
       ;;
       *_ios_sim_i386.h)
         DEFINE_CONDITION="TARGET_OS_IOS && TARGET_OS_SIMULATOR && TARGET_CPU_X86"
+      ;;
+      *_ios_sim_arm64.h)
+        DEFINE_CONDITION="TARGET_OS_IOS && TARGET_OS_SIMULATOR && TARGET_CPU_ARM64"
       ;;
       *_ios_arm64.h)
         DEFINE_CONDITION="TARGET_OS_IOS && TARGET_OS_EMBEDDED && TARGET_CPU_ARM64"

--- a/config/20-all-platforms.conf
+++ b/config/20-all-platforms.conf
@@ -38,6 +38,15 @@ my %targets = ();
         cflags           => add(sub { defined($ENV{'MACOS_MIN_SDK_VERSION'}) ? '-mmacosx-version-min=$(MACOS_MIN_SDK_VERSION)' : '-mmacosx-version-min=10.11'; }),
     },
 
+    "darwin64-arm64-cc" => {
+        inherit_from     => [ "darwin-common", asm("") ],
+        CFLAGS           => add("-Wall"),
+        cflags           => add("-arch arm64"),
+        lib_cppflags     => add("-DL_ENDIAN"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG",
+        perlasm_scheme   => "macosx",
+    },
+
     ## Apple WatchOS
 
     ## Base settings for iOS
@@ -79,6 +88,13 @@ my %targets = ();
     # Based on 10-main.conf: iphoneos-cross / darwin-i386-cc
     "ios-sim-cross-i386" => {
         inherit_from     => [ "darwin-i386-cc", "ios-cross-base" ],
+        sys_id           => "iOS",
+    },
+
+    ## Apple iOS simulator (arm64)
+    "ios-sim-cross-arm64" => {
+        inherit_from     => [ "darwin64-arm64-cc", "ios-cross-base" ],
+        cflags           => add("-target arm64-apple-ios13.0-simulator"),
         sys_id           => "iOS",
     },
 
@@ -146,6 +162,12 @@ my %targets = ();
     ## Apple macOS (i386)
     "macos-i386" => {
         inherit_from     => [ "darwin-i386-cc", "macos-base" ],
+        sys_id           => "macOS",
+    },
+
+    ## Apple macOS (arm64)
+    "macos64-arm64" => {
+        inherit_from     => [ "darwin64-arm64-cc", "macos-base" ],
         sys_id           => "macOS",
     },
 );


### PR DESCRIPTION
Add architecture configuration for OpenSSL based on [changes][1] suggested by @adib. Thank you so very much for figuring this out! ❤️

Since we're interested only in macOS and iOS, add only those simulators, cross-compiled for arm64. Don't add tvOS or watchOS support (yet).

### Limitations to be aware of

[1]: https://github.com/balthisar/openssl-xcframeworks/pull/6

This only lets the compiler to compile something as support for arm64 is not complete in OpenSSL (track this in openssl/openssl#12254). For example, you can see that we disable inline assembly, so the code might actually run slower. It's not much of an issue right now though since there is no arm64 hardware yet on the public market.

However, don't add the new arm64 architecture to the list of default architectures and targets to compile OpenSSL for (DEFAULTARCHS and DEFAULTTARGETS in `build-libssl.h`). This is because arm64 is currently supported only in Xcode betas, it's not available yet for the stable releases. Those wishing to experiment with arm64 architecture will have to specify appropriate targets manually on the command line.

### Platform-specific headers

New arm64 architecture for iOS Simulator is conflicting with arm64 architecture for the real iOS devices. Though the architecture is the same, the target is not. A different SDK is used to build arm64 for Apple Silicon devices, and it's not compatible in the strict sense.

OpenSSL currently has per-architecture headers with platform-specific details. Make sure that iOS ones don't conflict with iOS Simulator by making iOS use `openssl_ios_arm64.h` and iOS Simulator will be using `openssl_ios_sim_arm64.h`

### Other notes

There will be a separate PR after this one adding arm64 build support to CLOpenSSL specifically. This PR limits the changes to the files used by upstream, so that it's easier to submit them to upstream after more thorough testing.

Required reviews:

- [x] @vixentael