### PR TITLE
Build arm64 slices if requested

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,18 @@ BUILD_TARGETS += ios-sim-cross-i386 ios-sim-cross-x86_64
 BUILD_TARGETS += ios64-cross-arm64 ios64-cross-arm64e ios-cross-armv7s ios-cross-armv7
 BUILD_TARGETS += macos64-x86_64
 
+# Apple Silicon support is currently experimental. It is available only with
+# beta Xcode versions installed. Once iOS 14 and macOS 11 are released and
+# stable Xcode supports arm64, these settings are going to become default.
+ifeq ($(APPLE_SILICON_SUPPORT),yes)
+BUILD_ARCHS   += mac_arm64
+BUILD_TARGETS += macos64-arm64
+# FIXME(ilammy, 2020-10-22): iOS Simulator build for arm64 temporarily disabled.
+# A single framework cannot contain both iOS and iOS Simulator arm64 slices.
+# XCFrameworks should be able to support this combination in the future.
+# BUILD_TARGETS += ios-sim-cross-arm64
+endif
+
 BUILD_FLAGS += --version=$(VERSION)
 BUILD_FLAGS += --archs="$(BUILD_ARCHS)"
 BUILD_FLAGS += --targets="$(BUILD_TARGETS)"

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ endif
 ## OpenSSL version to build
 VERSION ?= 1.1.1g
 
-MIN_IOS_SDK = 8.0
-MIN_OSX_SDK = 10.9
+MIN_IOS_SDK = 10.0
+MIN_OSX_SDK = 10.11
 
 BUILD_ARCHS   += ios_i386 ios_x86_64 ios_arm64 ios_arm64e ios_armv7s ios_armv7
 BUILD_ARCHS   += mac_x86_64


### PR DESCRIPTION
Following up on #9, add arm64 to the list of architectures to build when requested by the user, this can be done by setting APPLE_SILICON_SUPPORT environment or Make variable to `yes`, for example:

    make APPLE_SILICON_SUPPORT=yes

We intend to provide arm64 builds in the default package, but until it is available in stable Xcode releases (see https://github.com/cossacklabs/openssl-apple/pull/9#issuecomment-716211861), arm64 capability will be under the feature gate to avoid breaking stable Xcode builds. Currently using APPLE_SILICON_SUPPORT requires Xcode 12+ beta to be active.

Also note that currently only the macOS build is enabled. It is possible to build arm64 for iOS Simulator, but it's currently not possible to package the results into the same fat binary along with the arm64 slice for the actual iOS devices. This issue will be solved later. It seems that using XCFrameworks should allow mixing targets the way we need it.

Finally, bring minimum platform versions in line with current recommendations of Xcode 12 and requirements of Themis.

Required reviews:

- [x] @vixentael