### PR TITLE
Extra package version digits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ endif
 ## OpenSSL version to build
 VERSION ?= 1.1.1g
 
+## Extra version of the distributed package
+PACKAGE_VERSION ?= 1
+
 MIN_IOS_SDK = 8.0
 MIN_OSX_SDK = 10.9
 
@@ -79,7 +82,7 @@ endif
 .PHONY: packages
 
 $(OUTPUT)/done.packages: $(OUTPUT)/done.build
-	@scripts/create-packages.sh
+	@PACKAGE_VERSION=$(PACKAGE_VERSION) scripts/create-packages.sh
 	@mkdir -p $(OUTPUT)
 	@touch $(OUTPUT)/done.packages
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,6 +12,9 @@ How to update to newer OpenSSL version, build, and publish a release.
 
    The version number is in the [`Makefile`](Makefile).
 
+   Increment `PACKAGE_VERSION` if you are repackaging the same OpenSSL version.
+   Otherwise, update `VERSION` to OpenSSL version and reset `PACKAGE_VERSION` to `1`.
+
    Also update tarball checksums in [`build-libssl.sh`](build-libssl.sh).
 
 3. **Update platform configuration.**
@@ -34,9 +37,9 @@ How to update to newer OpenSSL version, build, and publish a release.
    ```shell
    git add carthage
    git commit -S -e -m "OpenSSL 1.1.1g"
-   git tag -s -e -m "OpenSSL 1.1.1g" v1.1.107
+   git tag -s -e -m "OpenSSL 1.1.1g" v1.1.10701
    git push origin cossacklabs # Push the branch
-   git push origin v1.1.107    # Push the tag
+   git push origin v1.1.10701  # Push the tag
    ```
 
    Make will remind you how to do this.

--- a/create-openssl-framework.sh
+++ b/create-openssl-framework.sh
@@ -16,6 +16,8 @@ FWTYPE=$1
 FWNAME=openssl
 FWROOT=frameworks
 
+PACKAGE_VERSION="${PACKAGE_VERSION:-1}"
+
 if [ -d $FWROOT ]; then
     echo "Removing previous $FWNAME.framework copies"
     rm -rf $FWROOT
@@ -103,6 +105,12 @@ function get_min_sdk() {
 #   'g' = 103 -> 6 + 1 = 07 (zero-padded)
 #   1.1.107
 #
+# Also, to allow multiple releases of the same OpenSSL packaging
+# tack two extra version digits to the end using PACKAGE_VERSION:
+#
+#   1.1.10701
+#
+# This is what Debian might have called "1.1.1g-1".
 function get_openssl_version() {
     local opensslv=$1
     local std_version=$(awk '/define OPENSSL_VERSION_TEXT/ && !/-fips/ {print $5}' "$opensslv")
@@ -114,7 +122,8 @@ function get_openssl_version() {
     local subpatch=${std_version: -1}
     local subpatch_number=$(($(printf '%d' \'$subpatch) - 97 + 1))
     local normalized_version="${generic_version}$(printf '%02d' $subpatch_number)"
-    echo $normalized_version
+    local package_version="${normalized_version}$(printf '%02d' $PACKAGE_VERSION)"
+    echo $package_version
 }
 
 if [ $FWTYPE == "dynamic" ]; then


### PR DESCRIPTION
~~Teenage mutant ninja turtles~~ ...sorry.

Occasionally we need to publish the same OpenSSL version several times, such as when the version did not really change but Apple platforms did. Normally you increment the "patch version" for this, or some dedicated "package version", but we don't have that luxury with OpenSSL. We must keep the version strictly semver, and all the digits are already taken with OpenSSL version, even with some extra on top.

The current latest version of OpenSSL is 1.1.1h. However, semver does not allow letters so we transform that into 1.1.108:

`1.1.1h` => `1.1.(1 * 100) + ('h' - 'a' + 1)` => `1.1.108`

In the similar vein, add yet another 'package version' part to this
whole mess:

`1.1.1h-1` => `1.1.((1 * 100) + ('h' - 'a' + 1)) * 100 + 1` => `1.1.10801`

It's not the prettiest solution but... doin' what I can with what I got.

- This approach is semver-compatible, pleasing our fruit company overlords.
- The resulting version ordering is useful.
- Since the 1.1.107 has been the only release so far, migration to 1.1.10701 is smooth.
- The transformation is reversible and unambiguous (well, let's hope we won't need to release more than 100 versions of the same OpenSSL).

The source of truth for CLOpenSSL is the PACKAGE_VERSION variable in the Makefile. Bump it to release a new package version. Reset it to `1` when updating OpenSSL version.

Note that the tag names are using the same approach because they are significant to Carthage and CocoaPods.

Required reviews:
- [x] @vixentael
- [x] @shadinua