### PR TITLE
Use static frameworks for CocoaPods

### DIFF
--- a/cocoapods/CLOpenSSL.podspec.template
+++ b/cocoapods/CLOpenSSL.podspec.template
@@ -203,6 +203,10 @@ EOF
         done
     EOF
 
+    # Tell CocoaPods that the frameworks we publish are "static frameworks".
+    # This ensures correct resolution of transitive dependencies.
+    s.static_framework = true
+
     # Set the minimum platform versions. We just know the right ones from the
     # prebuilt frameworks we download.
     s.ios.deployment_target = min_target_ios

--- a/scripts/update-specs.sh
+++ b/scripts/update-specs.sh
@@ -71,10 +71,10 @@ sed -e "s/%%OPENSSL_VERSION%%/$version/g" \
     -e "s!%%GITHUB_REPO%%!$GITHUB_REPO!g" \
     -e "s/%%MIN_IOS_SDK%%/$MIN_IOS_SDK/g" \
     -e "s/%%MIN_OSX_SDK%%/$MIN_OSX_SDK/g" \
-    -e "s/%%IPHONE_ARCHIVE_NAME%%/$IPHONE_DYNAMIC_NAME/g" \
-    -e "s/%%IPHONE_ARCHIVE_HASH%%/$(shasum -a 256 "$OUTPUT/$IPHONE_DYNAMIC_NAME" | awk '{print $1}')/g" \
-    -e "s/%%MACOSX_ARCHIVE_NAME%%/$MACOSX_DYNAMIC_NAME/g" \
-    -e "s/%%MACOSX_ARCHIVE_HASH%%/$(shasum -a 256 "$OUTPUT/$MACOSX_DYNAMIC_NAME" | awk '{print $1}')/g" \
+    -e "s/%%IPHONE_ARCHIVE_NAME%%/$IPHONE_STATIC_NAME/g" \
+    -e "s/%%IPHONE_ARCHIVE_HASH%%/$(shasum -a 256 "$OUTPUT/$IPHONE_STATIC_NAME" | awk '{print $1}')/g" \
+    -e "s/%%MACOSX_ARCHIVE_NAME%%/$MACOSX_STATIC_NAME/g" \
+    -e "s/%%MACOSX_ARCHIVE_HASH%%/$(shasum -a 256 "$OUTPUT/$MACOSX_STATIC_NAME" | awk '{print $1}')/g" \
     $podspec.template > $podspec
 echo "Updated $podspec"
 echo


### PR DESCRIPTION
Okay, let's try this again. Previously we have experimented with 'static frameworks' – regular frameworks but with static libraries in them instead of dynamic ones. It turns out that a special CocoaPods option seems to make them work after all.

Convert CLOpenSSL into a static framework for CocoaPods too, like we already do for Carthage.