### PR TITLE
Fix minimum OS version setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,11 @@ VERSION ?= 1.1.1g
 
 ## Extra version of the distributed package
 PACKAGE_VERSION ?= 1
+export PACKAGE_VERSION
 
 MIN_IOS_SDK = 10.0
 MIN_OSX_SDK = 10.11
+export MIN_IOS_SDK MIN_OSX_SDK
 
 BUILD_ARCHS   += ios_i386 ios_x86_64 ios_arm64 ios_arm64e ios_armv7s ios_armv7
 BUILD_ARCHS   += mac_x86_64
@@ -94,7 +96,7 @@ endif
 .PHONY: packages
 
 $(OUTPUT)/done.packages: $(OUTPUT)/done.build
-	@PACKAGE_VERSION=$(PACKAGE_VERSION) scripts/create-packages.sh
+	@scripts/create-packages.sh
 	@mkdir -p $(OUTPUT)
 	@touch $(OUTPUT)/done.packages
 


### PR DESCRIPTION
PR #10 updated the minimum OS versions. This bakes them into the binaries which is good for Carthage, but CocoaPods also needs the versions specified in the podspec.

Make sure to export the MIN_IOS_SDK and MIN_OSX_SDK variables from the makefile as they are needed in `scripts/update-specs.sh` to properly fill in the minimum version requirements in generated CocoaPods spec. Otherwise we only pass them to the OpenSSL build scripts and end up with the spec requesting more broad minimum versions than the range actually supported by the binaries.

Instead of exporting the variables to specific script invocations, just make sure that Make exports them to all tools that it launches. That way it's harder to forget to add them for some script.