### PR TITLE
Make podspec summary short

### DIFF
--- a/cocoapods/CLOpenSSL.podspec.template
+++ b/cocoapods/CLOpenSSL.podspec.template
@@ -13,7 +13,8 @@ Pod::Spec.new do |s|
     # Project metadata
     s.name     = "CLOpenSSL"
     s.version  = "#{openssl_version}"
-    s.summary  = "Pre-built OpenSSL framework for iOS and macOS: full-featured toolkit for the TLS and SSL protocols as well as a general-purpose cryptography library."
+    s.summary  = "Pre-built OpenSSL framework for iOS and macOS."
+    s.description = "OpenSSL is a full-featured toolkit for the TLS and SSL protocols as well as a general-purpose cryptography library."
     s.homepage = "https://www.openssl.org/"
     s.authors  = [
         "Andy Polyakov",


### PR DESCRIPTION
CocoaPods issues a warning if the summary is long, it expects it to be tweet-sized (under 140 characters). Well, split the current summary into a short part and move OpenSSL description into `description`.

Now it should be possible to lint the spec without `--allow-warnings`.