### PR TITLE
XCFramework support and packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,7 @@ endif
 # Enable this architecture only when requested.
 ifeq ($(APPLE_SILICON_SUPPORT),yes)
 BUILD_TARGETS += macos64-arm64
-# FIXME(ilammy, 2020-10-22): iOS Simulator build for arm64 temporarily disabled.
-# A single framework cannot contain both iOS and iOS Simulator arm64 slices.
-# XCFrameworks should be able to support this combination in the future.
-# BUILD_TARGETS += ios-sim-cross-arm64
+BUILD_TARGETS += ios-sim-cross-arm64
 endif
 
 BUILD_FLAGS += --version=$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,6 @@ MIN_IOS_SDK = 10.0
 MIN_OSX_SDK = 10.11
 export MIN_IOS_SDK MIN_OSX_SDK
 
-BUILD_ARCHS   += ios_i386 ios_x86_64 ios_arm64 ios_armv7s ios_armv7
-BUILD_ARCHS   += mac_x86_64
 BUILD_TARGETS += ios-sim-cross-i386 ios-sim-cross-x86_64
 BUILD_TARGETS += ios64-cross-arm64 ios-cross-armv7s ios-cross-armv7
 BUILD_TARGETS += macos64-x86_64
@@ -39,7 +37,6 @@ endif
 # Not all currently used Xcode versions support building for Apple Silicon.
 # Enable this architecture only when requested.
 ifeq ($(APPLE_SILICON_SUPPORT),yes)
-BUILD_ARCHS   += mac_arm64
 BUILD_TARGETS += macos64-arm64
 # FIXME(ilammy, 2020-10-22): iOS Simulator build for arm64 temporarily disabled.
 # A single framework cannot contain both iOS and iOS Simulator arm64 slices.
@@ -48,7 +45,6 @@ BUILD_TARGETS += macos64-arm64
 endif
 
 BUILD_FLAGS += --version=$(VERSION)
-BUILD_FLAGS += --archs="$(BUILD_ARCHS)"
 BUILD_FLAGS += --targets="$(BUILD_TARGETS)"
 BUILD_FLAGS += --min-ios-sdk=$(MIN_IOS_SDK)
 BUILD_FLAGS += --min-macos-sdk=$(MIN_OSX_SDK)

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -577,11 +577,20 @@ if [ ${#OPENSSLCONF_ALL[@]} -gt 1 ]; then
 
     # Determine define condition
     case "${OPENSSLCONF_CURRENT}" in
+      *_ios_armv7s.h)
+        DEFINE_CONDITION="TARGET_OS_IOS && TARGET_OS_EMBEDDED && TARGET_CPU_ARM && defined(__ARM_ARCH_7S__)"
+      ;;
+      *_ios_armv7.h)
+        DEFINE_CONDITION="TARGET_OS_IOS && TARGET_OS_EMBEDDED && TARGET_CPU_ARM && !defined(__ARM_ARCH_7S__)"
+      ;;
       *_ios_arm64.h)
         DEFINE_CONDITION="TARGET_OS_IOS && TARGET_OS_EMBEDDED && TARGET_CPU_ARM64"
       ;;
       *_ios_arm64e.h)
         DEFINE_CONDITION="TARGET_OS_IOS && TARGET_OS_EMBEDDED && TARGET_CPU_ARM64E"
+      ;;
+      *_ios_sim_i386.h)
+        DEFINE_CONDITION="TARGET_OS_IOS && TARGET_OS_SIMULATOR && TARGET_CPU_X86"
       ;;
       *_ios_sim_x86_64.h)
         DEFINE_CONDITION="TARGET_OS_IOS && TARGET_OS_SIMULATOR && TARGET_CPU_X86_64"

--- a/cocoapods/CLOpenSSL.podspec.template
+++ b/cocoapods/CLOpenSSL.podspec.template
@@ -205,12 +205,4 @@ EOF
 
     # This is prebuilt framework that will be vendored into the final app.
     s.vendored_frameworks = "#{XCFramework_archive_name}/openssl.xcframework"
-
-    # FIXME(ilammy, 2020-10-23): use XCFrameworks for full arm64 support
-    # The framework produced by CLOpenSSL does not contain arm64 slice for
-    # iOS Simulator since it conflicts with arm64 slice for the real iOS.
-    # Fixing this requires migration to XCFrameworks and making CLOpenSSL
-    # building arm64 for both iOS and iOS Simulator. See T1406 for status.
-    s.ios.pod_target_xcconfig  = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-    s.ios.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/cocoapods/CLOpenSSL.podspec.template
+++ b/cocoapods/CLOpenSSL.podspec.template
@@ -5,13 +5,11 @@ Pod::Spec.new do |s|
     min_target_osx  = "%%MIN_OSX_SDK%%"
 
     github_repo = "%%GITHUB_REPO%%"
-    iPhone_archive_name = "%%IPHONE_ARCHIVE_NAME%%"
-    iPhone_archive_hash = "%%IPHONE_ARCHIVE_HASH%%"
-    macOSX_archive_name = "%%MACOSX_ARCHIVE_NAME%%"
-    macOSX_archive_hash = "%%MACOSX_ARCHIVE_HASH%%"
+    XCFramework_archive_name = "%%XCFRAMEWORK_ARCHIVE_NAME%%"
+    XCFramework_archive_hash = "%%XCFRAMEWORK_ARCHIVE_HASH%%"
 
     # Project metadata
-    s.name     = "CLOpenSSL"
+    s.name     = "CLOpenSSL-XCF"
     s.version  = "#{openssl_version}"
     s.summary  = "Pre-built OpenSSL framework for iOS and macOS."
     s.description = "OpenSSL is a full-featured toolkit for the TLS and SSL protocols as well as a general-purpose cryptography library."
@@ -182,26 +180,22 @@ EOF
     # properly is so painful to setup, "pod install" will download prebuilt binaries
     # that we publish elsewhere (not in the git repo with the build script code).
     s.prepare_command = <<-EOF
-        (
-            echo "#{iPhone_archive_name} #{iPhone_archive_hash}"
-            echo "#{macOSX_archive_name} #{macOSX_archive_hash}"
-        ) | while read name hash
-        do
-            echo "Downloading $name..."
-            curl --location --output "$name" \
-                "#{github_repo}/releases/download/v#{openssl_version}/$name"
-            echo "Verifying $name..."
-            if [[ "$(shasum -a 256 "$name" | awk '{print $1}')" != "$hash" ]]
-            then
-                echo "Checksum mismatch for $name"
-                exit 1
-            fi
-            echo "Unpacking $name..."
-            unzip "$name"
-            rm "$name"
-            mkdir -p "$name"
-            mv openssl.framework "$name"
-        done
+        name="#{XCFramework_archive_name}"
+        hash="#{XCFramework_archive_hash}"
+        echo "Downloading $name..."
+        curl --location --output "$name" \
+            "#{github_repo}/releases/download/v#{openssl_version}/$name"
+        echo "Verifying $name..."
+        if [[ "$(shasum -a 256 "$name" | awk '{print $1}')" != "$hash" ]]
+        then
+            echo "Checksum mismatch for $name"
+            exit 1
+        fi
+        echo "Unpacking $name..."
+        unzip "$name"
+        rm "$name"
+        mkdir -p "$name"
+        mv openssl.xcframework "$name"
     EOF
 
     # Set the minimum platform versions. We just know the right ones from the
@@ -209,9 +203,8 @@ EOF
     s.ios.deployment_target = min_target_ios
     s.osx.deployment_target = min_target_osx
 
-    # These are prebuilt frameworks that will be vendored into the final app.
-    s.ios.vendored_frameworks = "#{iPhone_archive_name}/openssl.framework"
-    s.osx.vendored_frameworks = "#{macOSX_archive_name}/openssl.framework"
+    # This is prebuilt framework that will be vendored into the final app.
+    s.vendored_frameworks = "#{XCFramework_archive_name}/openssl.xcframework"
 
     # FIXME(ilammy, 2020-10-23): use XCFrameworks for full arm64 support
     # The framework produced by CLOpenSSL does not contain arm64 slice for

--- a/config/20-all-platforms.conf
+++ b/config/20-all-platforms.conf
@@ -45,6 +45,20 @@ my %targets = ();
 
     ## Apple iOS
 
+    # Device (armv7s)
+    "ios-cross-armv7s" => {
+        inherit_from     => [ "darwin-common", "ios-cross-base", asm("armv4_asm") ],
+        cflags           => add("-arch armv7s"),
+        perlasm_scheme   => "ios32",
+        sys_id           => "iOS",
+    },
+    # Device (armv7)
+    "ios-cross-armv7" => {
+        inherit_from     => [ "darwin-common", "ios-cross-base", asm("armv4_asm") ],
+        cflags           => add("-arch armv7"),
+        perlasm_scheme   => "ios32",
+        sys_id           => "iOS",
+    },
     # Device (arm64)
     "ios64-cross-arm64" => {
         inherit_from     => [ "darwin-common", "ios-cross-base", asm("aarch64_asm") ],
@@ -59,6 +73,11 @@ my %targets = ();
         cflags           => add("-arch arm64e"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
         perlasm_scheme   => "ios64",
+        sys_id           => "iOS",
+    },
+    # Simulator (i386)
+    "ios-sim-cross-i386" => {
+        inherit_from     => [ "darwin-i386-cc", "ios-cross-base" ],
         sys_id           => "iOS",
     },
     # Simulator (x86_64)

--- a/scripts/create-packages.sh
+++ b/scripts/create-packages.sh
@@ -10,13 +10,11 @@
 #
 #     OUTPUT        output directory            (default: output)
 #     FLAVORS       package flavors to build    (default: static dynamic)
-#     PLATFORMS     platforms to package for    (default: iPhone MacOSX)
 
 set -eu
 
 OUTPUT=${OUTPUT:-output}
 FLAVORS=${FLAVORS:-static dynamic}
-PLATFORMS=${PLATFORMS:-iPhone MacOSX}
 
 die() {
     echo 2>&1 "$@"
@@ -49,23 +47,22 @@ for flavor in $FLAVORS
 do
     ./create-openssl-framework.sh $flavor
 
-    for platform in $PLATFORMS
-    do
-        echo "Packaging $flavor framework for $platform"
+    echo "Packaging $flavor XCFramework"
 
-        # zip stores relative paths, cd into directory to keep them tidy.
-        # Is also important to preserve symlinks for macOS frameworks.
-        cd frameworks/$platform
-        zip --recurse-paths --symlinks --quiet \
-            openssl.zip openssl.framework
-        cd "$OLDPWD"
+    # zip stores relative paths, cd into directory to keep them tidy.
+    # Is also important to preserve symlinks for macOS frameworks.
+    cd frameworks
+    zip --recurse-paths --symlinks --quiet \
+        openssl.zip openssl.xcframework
+    cd "$OLDPWD"
 
-        mv frameworks/$platform/openssl.zip \
-            "$OUTPUT/openssl-$flavor-$platform.zip"
+    mv frameworks/openssl.zip \
+        "$OUTPUT/openssl-$flavor-xcframework.zip"
 
-        framework_version frameworks/$platform/openssl.framework \
-            > "$OUTPUT/version"
+    # Use macOS framework as a reference for versioning.
+    # (They are all the same, but we need non-XCFramework).
+    framework_version frameworks/MacOSX/openssl.framework \
+        > "$OUTPUT/version"
 
-        echo "Packaged $flavor framework for $platform"
-    done
+    echo "Packaged $flavor XCFramework"
 done

--- a/scripts/update-specs.sh
+++ b/scripts/update-specs.sh
@@ -22,15 +22,11 @@ MIN_OSX_SDK=${MIN_OSX_SDK:-10.9}
 GITHUB_REPO="https://github.com/cossacklabs/openssl-apple"
 
 # Output framework archive names
-IPHONE_STATIC_NAME="openssl-static-iPhone.zip"
-MACOSX_STATIC_NAME="openssl-static-MacOSX.zip"
-IPHONE_DYNAMIC_NAME="openssl-dynamic-iPhone.zip"
-MACOSX_DYNAMIC_NAME="openssl-dynamic-MacOSX.zip"
+XCFRAMEWORK_STATIC_NAME="openssl-static-xcframework.zip"
+XCFRAMEWORK_DYNAMIC_NAME="openssl-dynamic-xcframework.zip"
 OUTPUT_ARCHIVES=(
-    "$IPHONE_STATIC_NAME"
-    "$MACOSX_STATIC_NAME"
-    "$IPHONE_DYNAMIC_NAME"
-    "$MACOSX_DYNAMIC_NAME"
+    "$XCFRAMEWORK_STATIC_NAME"
+    "$XCFRAMEWORK_DYNAMIC_NAME"
 )
 
 die() {
@@ -66,15 +62,14 @@ echo
 
 # Unfortuntely, CocoaPods does not support static frameworks very well
 # so we provide only dynamic flavor of the Podspec.
-podspec="cocoapods/CLOpenSSL.podspec"
+podspec="cocoapods/CLOpenSSL-XCF.podspec"
+template="cocoapods/CLOpenSSL.podspec.template"
 sed -e "s/%%OPENSSL_VERSION%%/$version/g" \
     -e "s!%%GITHUB_REPO%%!$GITHUB_REPO!g" \
     -e "s/%%MIN_IOS_SDK%%/$MIN_IOS_SDK/g" \
     -e "s/%%MIN_OSX_SDK%%/$MIN_OSX_SDK/g" \
-    -e "s/%%IPHONE_ARCHIVE_NAME%%/$IPHONE_DYNAMIC_NAME/g" \
-    -e "s/%%IPHONE_ARCHIVE_HASH%%/$(shasum -a 256 "$OUTPUT/$IPHONE_DYNAMIC_NAME" | awk '{print $1}')/g" \
-    -e "s/%%MACOSX_ARCHIVE_NAME%%/$MACOSX_DYNAMIC_NAME/g" \
-    -e "s/%%MACOSX_ARCHIVE_HASH%%/$(shasum -a 256 "$OUTPUT/$MACOSX_DYNAMIC_NAME" | awk '{print $1}')/g" \
-    $podspec.template > $podspec
+    -e "s/%%XCFRAMEWORK_ARCHIVE_NAME%%/$XCFRAMEWORK_DYNAMIC_NAME/g" \
+    -e "s/%%XCFRAMEWORK_ARCHIVE_HASH%%/$(shasum -a 256 "$OUTPUT/$XCFRAMEWORK_DYNAMIC_NAME" | awk '{print $1}')/g" \
+    $template > $podspec
 echo "Updated $podspec"
 echo


### PR DESCRIPTION
Following #20, fix CLOpenSSL build with XCFrameworks.

<details>

- Drop support for OpenSSL 1.0.x

  Upstream has removed support for OpenSSL 1.0.x, now the architectures to build for are specified only via `--targets` option, `--archs` is not supported. Do not set it up and do not pass it to the build script.

- Restore removed iOS 10.0 targets

  Upstream has moved to using iOS 12.0 as the default minimum supported version. With this, several architectures has been removed. However, we are still using iOS 10.0 as our minimum supported version and still need the removed 32-bit architectures: armv7 and arm7s for iOS devices and i386 for simulators. If they are not included in the binary frameworks, Xcode will complain about missing architecture slices.

- Adjust packaging to XCFrameworks

  Upstream has moved to packaging a single XCFramework with all targets in it. This brings good news as now Apple Silicon will be supported for iOS Simulators, removing the need for some hacks. This also brings bad news because this is a breaking change for CLOpenSSL users.

  In order to avoid breakage, **the packages are renamed**. CocoaPods' pod is now named `CLOpenSSL-XCF` and Carthage binary dependencies should be retrieved using the `openssl-{static,dynamic}-xcframework.json` specs.

  The reason for this is that Carthage users will have to adjust their binary dependencies to download the unified XCFramework instead of two separate frameworks for iOS and macOS. They will also need to adjust their Xcode projects to use `openssl.xcframework` instead of the usual `openssl.framework`. While CocoaPods should automatically figure this out, we won't take chances and will make this a flag day for CocoaPods users as well.

  This is also a breaking change for our build system as the upstream build system now builds iOS (device) and iOS Simulator frameworks separately. This means that there are two `openssl.framework` binaries for iOS and neither is usable with both iOS and iOS Simulator, as it was before. We can't package them as an "iPhone" target to maintain backward compatibility with previous Carthage packaging.

  Overall, this means that **the next release of CLOpenSSL is a flag day** for its users. Users of the previous version MUST migrate their builds if they wish to get future updates. Otherwise they can continue using 1.1.10802, there will be no updates to existing "CLOpenSSL" packages.

- Include arm64 slice for iOS Simulators

  Now that we are building XCFrameworks, we can also include the arm64 slice for iOS Simulator (if Xcode supports Apple Silicon), without getting any errors from linker.

  It is also not necessary now to exclude this slice from projects generated by CocoaPods. That is, for CLOpenSSL consumers. Upstream library users like Themis might still need the exclusion until they are producing XCFramework-compatible artifacts. However, CLOpenSSL does not need to enforce this exclusion by itself from now on.

</details>

With this, running

```
make
```

should build and package two XCFrameworks, with static and dynamic libraries in them. XCFrameworks are unified, they contain macOS, iOS, and iOS Simulator binaries. You can link them into any type of project.

As noted in the details, this changes renames CLOpenSSL packages.

- **Carthage** users should use the following spec from now on:

  ```diff
  -binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-iPhone.json" ...
  -binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-MacOSX.json" ...
  +binary "https://raw.githubusercontent.com/cossacklabs/openssl-apple/cossacklabs/carthage/openssl-static-xcframework.json" ...
  # or "dynamic" if you are using dynamic frameworks
  ```

- **CocoaPods** users should use the `CLOpenSSL-XCF` pod instead of `CLOpenSSL`.

---

* [x] @julepka approve