### PR TITLE
add Swift Package Manager support with xcframework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ include/openssl
 *.xcodeproj/project.xcworkspace
 *.xcodeproj/xcuserdata
 Pods
+.swiftpm/
 
 # Cossack Labs packaging
 output

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ ifeq ($(GOAL),specs)
 	@echo
 	@echo "    # The tag must contain the 'semversified' version of OpenSSL"
 	@echo "    # (e.g., $$(cat "$(OUTPUT)/version") instead of $(VERSION))"
-	@echo "    git tag -sem \"OpenSSL $(VERSION)\" v$$(cat "$(OUTPUT)/version")"
+	@echo "    git tag -sem \"OpenSSL $(VERSION)\" $$(cat "$(OUTPUT)/version")"
 	@echo "    git push --tags"
 	@echo
 	@echo "Finally, create a pre-release on GitHub from this tag:"

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "cl-openssl",
+    products: [
+        .library(
+            name: "cl-openssl",
+            targets: ["openssl"]),
+    ],
+    dependencies: [],
+    targets: [
+        .binaryTarget(name: "openssl",
+                      // update version in URL path
+                      url:"https://github.com/julepka/openssl-apple/releases/download/1.1.1080202/openssl-static-xcframework.zip",
+                      // Run from package directory:
+                      // $swift package compute-checksum output/openssl-static-xcframework.zip
+                      checksum: "77b9a36297a2cade7bb6db5282570740a2af7b1e5083f126f46ca2671b14d73e"),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -14,9 +14,9 @@ let package = Package(
     targets: [
         .binaryTarget(name: "openssl",
                       // update version in URL path
-                      url:"https://github.com/julepka/openssl-apple/releases/download/1.1.1080202/openssl-static-xcframework.zip",
+                      url:"https://github.com/cossacklabs/openssl-apple/releases/download/1.1.10803/openssl-static-xcframework.zip",
                       // Run from package directory:
                       // swift package compute-checksum output/openssl-static-xcframework.zip
-                      checksum: "77b9a36297a2cade7bb6db5282570740a2af7b1e5083f126f46ca2671b14d73e"),
+                      checksum: "dd884d18e49fd46a4df2757b57b3862003b8bf12bd792459bef20e68ccacb9d5"),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
                       // update version in URL path
                       url:"https://github.com/julepka/openssl-apple/releases/download/1.1.1080202/openssl-static-xcframework.zip",
                       // Run from package directory:
-                      // $swift package compute-checksum output/openssl-static-xcframework.zip
+                      // swift package compute-checksum output/openssl-static-xcframework.zip
                       checksum: "77b9a36297a2cade7bb6db5282570740a2af7b1e5083f126f46ca2671b14d73e"),
     ]
 )

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,6 +17,9 @@ How to update to newer OpenSSL version, build, and publish a release.
 
    Also update tarball checksums in [`build-libssl.sh`](build-libssl.sh).
 
+   Update binary framework link with the upcoming version in [`Package.swift`](Package.swift) file.
+   https://github.com/cossacklabs/openssl-apple/releases/download/1.1.10701/openssl-static-xcframework.zip
+
 3. **Update platform configuration.**
 
    Things like minimum OS SDK versions, architectures, etc.
@@ -34,12 +37,14 @@ How to update to newer OpenSSL version, build, and publish a release.
 
 5. **Commit, tag, push the release.**
 
+   Tag should be in a semver format.
+
    ```shell
    git add carthage
    git commit -S -e -m "OpenSSL 1.1.1g"
-   git tag -s -e -m "OpenSSL 1.1.1g" v1.1.10701
+   git tag -s -e -m "OpenSSL 1.1.1g" 1.1.10701
    git push origin cossacklabs # Push the branch
-   git push origin v1.1.10701  # Push the tag
+   git push origin 1.1.10701  # Push the tag
    ```
 
    Make will remind you how to do this.
@@ -47,20 +52,20 @@ How to update to newer OpenSSL version, build, and publish a release.
    Take care to make signed commits and tags, this is important for vanity.
 
    Congratulations!
-   You have just published a broken Carthage package.
+   You have just published broken Carthage and SPM packages :)
 
 6. **Publish GitHub release with binary framework files.**
 
    Go to GitHub release page for the tag:
 
-   https://github.com/cossacklabs/openssl-apple/releases/tag/v1.1.107
+   https://github.com/cossacklabs/openssl-apple/releases/tag/1.1.107
 
    press **Edit tag** and upload `*.zip` packages from `output` directory.
 
    Also, describe the release, press the **Publish release** when done.
 
    Congratulations!
-   You should have fixed the Carthage package with this.
+   You should have fixed the Carthage and SPM packages with this.
 
 7. **Publish podspec.**
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,15 +17,14 @@ How to update to newer OpenSSL version, build, and publish a release.
 
    Also update tarball checksums in [`build-libssl.sh`](build-libssl.sh).
 
-   Update binary framework link with the upcoming version in [`Package.swift`](Package.swift) file.
-   https://github.com/cossacklabs/openssl-apple/releases/download/1.1.10701/openssl-static-xcframework.zip
-
 3. **Update platform configuration.**
 
    Things like minimum OS SDK versions, architectures, etc.
    You can find all this in the [`Makefile`](Makefile).
 
 4. **Build OpenSSL.**
+
+   To build from scratch - remove output folder.
 
    ```shell
    make
@@ -35,12 +34,25 @@ How to update to newer OpenSSL version, build, and publish a release.
    Not only it builds the library, this also packages it,
    and updates the project specs.
 
-5. **Commit, tag, push the release.**
+5. **Update SPM package settings**
+
+	 In the [`Package.swift`](Package.swift) file
+     update binary framework link with the upcoming version (semver format)
+     https://github.com/cossacklabs/openssl-apple/releases/download/1.1.10701/openssl-static-xcframework.zip
+
+     Also, update xcframework checksum.
+ 
+     ```shell
+     swift package compute-checksum output/openssl-static-xcframework.zip
+     ```
+
+6. **Commit, tag, push the release.**
 
    Tag should be in a semver format.
 
    ```shell
    git add carthage
+   git add Package.swift
    git commit -S -e -m "OpenSSL 1.1.1g"
    git tag -s -e -m "OpenSSL 1.1.1g" 1.1.10701
    git push origin cossacklabs # Push the branch
@@ -54,7 +66,7 @@ How to update to newer OpenSSL version, build, and publish a release.
    Congratulations!
    You have just published broken Carthage and SPM packages :)
 
-6. **Publish GitHub release with binary framework files.**
+7. **Publish GitHub release with binary framework files.**
 
    Go to GitHub release page for the tag:
 
@@ -67,7 +79,7 @@ How to update to newer OpenSSL version, build, and publish a release.
    Congratulations!
    You should have fixed the Carthage and SPM packages with this.
 
-7. **Publish podspec.**
+8. **Publish podspec.**
 
    ```shell
    pod trunk push cocoapods/CLOpenSSL.podspec


### PR DESCRIPTION
Introducing Swift Package Manager support based on xcframework.

Named the package "cl-openssl" to avoid collisions with other possible "openssl" packages. The package points to the xcframework binary that is added to the release assets.

For each new release we'll need to:
- attach the xcframeworks binary to each release as an asset
- update the version number in Package.swift
- commit the change -> create release (so, the release reference the corresponding commit)

Before merging, I need to clarify the versioning, so the path to the binary contains a future release (future version). So, the new release references the commit with the URL pointing to it.