### PR TITLE
OpenSSL 1.1.1k

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ endif
 #===== Versioning ==============================================================
 
 ## OpenSSL version to build
-VERSION ?= 1.1.1h
+VERSION ?= 1.1.1k
 
 ## Extra version of the distributed package
-PACKAGE_VERSION ?= 3
+PACKAGE_VERSION ?= 1
 export PACKAGE_VERSION
 
 MIN_IOS_SDK = 10.0

--- a/Package.swift
+++ b/Package.swift
@@ -14,9 +14,9 @@ let package = Package(
     targets: [
         .binaryTarget(name: "openssl",
                       // update version in URL path
-                      url:"https://github.com/cossacklabs/openssl-apple/releases/download/1.1.10803/openssl-static-xcframework.zip",
+                      url:"https://github.com/cossacklabs/openssl-apple/releases/download/1.1.11101/openssl-static-xcframework.zip",
                       // Run from package directory:
                       // swift package compute-checksum output/openssl-static-xcframework.zip
-                      checksum: "4e03d2d4d5ee25216dc6353dc3d3336a23ee7191533fe9951ad607510b758a3b"),
+                      checksum: "ea9c1a3fa59a51c13a811f4f11ada330d9e3993c3bc225db102127595e2d97ba"),
     ]
 )

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -25,7 +25,7 @@ set -u
 # SCRIPT DEFAULTS
 
 # Default version in case no version is specified
-DEFAULTVERSION="1.1.1h"
+DEFAULTVERSION="1.1.1k"
 
 # Default (=full) set of targets (OpenSSL >= 1.1.1) to build
 DEFAULTTARGETS=`cat <<TARGETS
@@ -37,7 +37,7 @@ tvos-sim-cross-x86_64 tvos64-cross-arm64
 TARGETS`
 
 # Minimum iOS/tvOS SDK version to build for
-IOS_MIN_SDK_VERSION="12.0"
+IOS_MIN_SDK_VERSION="10.0"
 MACOS_MIN_SDK_VERSION="10.15"
 CATALYST_MIN_SDK_VERSION="10.15"
 WATCHOS_MIN_SDK_VERSION="4.0"
@@ -487,6 +487,7 @@ OPENSSL_CHECKSUMS="
   1.0.2u ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16
   1.1.1g ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46
   1.1.1h 5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9
+  1.1.1k 892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5
 "
 checksum_checked=false
 while read version expectedSHA256; do

--- a/carthage/openssl-dynamic-xcframework.json
+++ b/carthage/openssl-dynamic-xcframework.json
@@ -1,3 +1,4 @@
 {
+    "1.1.11101": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.1.11101/openssl-dynamic-xcframework.zip",
     "1.1.10803": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.1.10803/openssl-dynamic-xcframework.zip",
 }

--- a/carthage/openssl-static-xcframework.json
+++ b/carthage/openssl-static-xcframework.json
@@ -1,3 +1,4 @@
 {
+    "1.1.11101": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.1.11101/openssl-static-xcframework.zip",
     "1.1.10803": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.1.10803/openssl-static-xcframework.zip",
 }

--- a/config/20-all-platforms.conf
+++ b/config/20-all-platforms.conf
@@ -94,16 +94,6 @@ my %targets = ();
 
     ## Apple macOS
 
-    # Base (arm64)
-    "darwin64-arm64-cc" => {
-        inherit_from     => [ "darwin-common", asm("aarch64_asm") ],
-        CFLAGS           => add("-Wall"),
-        cflags           => add("-arch arm64"),
-        lib_cppflags     => add("-DL_ENDIAN"),
-        bn_ops           => "SIXTY_FOUR_BIT_LONG",
-        perlasm_scheme   => "ios64",
-    },
-
     # Device (x86_64)
     "macos64-x86_64" => {
         inherit_from     => [ "darwin64-x86_64-cc", "macos-base" ],


### PR DESCRIPTION
OpenSSL 1.1.1k update is here!

It was not a flawless update even though the release notes do not mention significant changes. 

* We no longer need to configure our own `darwin64-arm64-cc`. It should work out of the box. If you declare the platform name as `darwin64-arm64-cc` you'll get an error message about a duplicate platform name.
* Looks like they've added a more strict iOS version validation for different platforms. So, the build for i386 simulator failed because the minimum iOS version was set to 12.0 while the 32bit system maximum iOS version is iOS 10. So, I've lowered the version in `build-libssl.sh`

Tested by adding the generated XCF to the Themis test project.

I wonder how should I merge it so the last commit stays verified? 🧐 So I can tag it for the release.