### PR TITLE
docs and specs updates

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,15 +36,16 @@ How to update to newer OpenSSL version, build, and publish a release.
 
 5. **Update SPM package settings**
 
-	 In the [`Package.swift`](Package.swift) file
-     update binary framework link with the upcoming version (semver format)
-     https://github.com/cossacklabs/openssl-apple/releases/download/1.1.10701/openssl-static-xcframework.zip
+	 Update [`Package.swift`](Package.swift) file with the new URL of the binary framework and its checksum:
 
-     Also, update xcframework checksum.
- 
-     ```shell
-     swift package compute-checksum output/openssl-static-xcframework.zip
-     ```
+   ```swift
+   .binaryTarget(name: "openssl",
+              // update version in URL path
+              url:"https://github.com/cossacklabs/openssl-apple/releases/download/1.1.10701/openssl-static-xcframework.zip",
+              // Run from package directory:
+              // swift package compute-checksum output/openssl-static-xcframework.zip
+              checksum: "77b9a36297a2cade7bb6db5282570740a2af7b1e5083f126f46ca2671b14d73e"),
+   ```
 
 6. **Commit, tag, push the release.**
 

--- a/carthage/README.md
+++ b/carthage/README.md
@@ -22,3 +22,5 @@ OpenSSL versions are translated to Carthage versions by renumbering like this:
 | 1.1.1g          | 1.1.107          |
 | 1.1.1h          | 1.1.10801        |
 | 1.1.1h          | 1.1.10802        | (no changes in OpenSSL, added arm64)
+| 1.1.1h          | 1.1.10803        | (no changes in OpenSSL, XCF support)
+| 1.1.1k          | 1.1.11101        | (XCF-only)

--- a/carthage/openssl-dynamic-xcframework.json
+++ b/carthage/openssl-dynamic-xcframework.json
@@ -1,4 +1,4 @@
 {
-    "1.1.11101": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.1.11101/openssl-dynamic-xcframework.zip",
-    "1.1.10803": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.1.10803/openssl-dynamic-xcframework.zip",
+    "1.1.11101": "https://github.com/cossacklabs/openssl-apple/releases/download/1.1.11101/openssl-dynamic-xcframework.zip",
+    "1.1.10803": "https://github.com/cossacklabs/openssl-apple/releases/download/1.1.10803/openssl-dynamic-xcframework.zip",
 }

--- a/carthage/openssl-static-xcframework.json
+++ b/carthage/openssl-static-xcframework.json
@@ -1,4 +1,4 @@
 {
-    "1.1.11101": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.1.11101/openssl-static-xcframework.zip",
-    "1.1.10803": "https://github.com/cossacklabs/openssl-apple/releases/download/v1.1.10803/openssl-static-xcframework.zip",
+    "1.1.11101": "https://github.com/cossacklabs/openssl-apple/releases/download/1.1.11101/openssl-static-xcframework.zip",
+    "1.1.10803": "https://github.com/cossacklabs/openssl-apple/releases/download/1.1.10803/openssl-static-xcframework.zip",
 }

--- a/cocoapods/CLOpenSSL.podspec.template
+++ b/cocoapods/CLOpenSSL.podspec.template
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
 
     # Source code location. Actually, this is the script that builds OpenSSL
     # after downloading its source tarball from the official site.
-    s.source  = { :git => "#{github_repo}.git", :tag => "v#{openssl_version}" }
+    s.source  = { :git => "#{github_repo}.git", :tag => "#{openssl_version}" }
     s.license = {
         :type => "OpenSSL/SSLeay",
         :text => <<~EOF

--- a/scripts/update-specs.sh
+++ b/scripts/update-specs.sh
@@ -51,7 +51,7 @@ do
     else
         (
             head -1 "$spec" 2> /dev/null || echo "{"
-            echo "    \"$version\": \"$GITHUB_REPO/releases/download/v$version/$package\","
+            echo "    \"$version\": \"$GITHUB_REPO/releases/download/$version/$package\","
             tail +2 "$spec" 2> /dev/null || echo "}"
         ) > "$OUTPUT/tmp.spec"
         mv "$OUTPUT/tmp.spec" "$spec"


### PR DESCRIPTION
Minor updates were missed during the previous release.

- minor update to RELEASING.md wording
- updated Carthage README.md for 1.1.10803 and 1.1.11101
- fixed links in templates for Carthage and CocoaPods: removed "v" for tag/release files path. When I was releasing the version, I've removed the "v" for podspec but forgot to update the template.